### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/KarimHussein04/e79f3ea7-11d2-42d1-bc2b-62265b90ffac/ae22b0f2-be77-47fb-84e4-853fad259744/_apis/work/boardbadge/28085d39-b6b5-4695-ad35-7d8bf0c5e92b)](https://dev.azure.com/KarimHussein04/e79f3ea7-11d2-42d1-bc2b-62265b90ffac/_boards/board/t/ae22b0f2-be77-47fb-84e4-853fad259744/Microsoft.RequirementCategory)
 # agile-final-project
 Agile Development and Scrum Final Project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/KarimHussein04/e79f3ea7-11d2-42d1-bc2b-62265b90ffac/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.